### PR TITLE
Add support for kilometers

### DIFF
--- a/helpers/metric.js
+++ b/helpers/metric.js
@@ -1,0 +1,6 @@
+const factor = 1.609344;
+
+export default {
+    milesToKm: (miles) => miles / factor,
+    kmToMiles: (km) => km * factor
+}


### PR DESCRIPTION
Users can now also tweet progress in kilometers, and will be converted to miles before adding to the database (so database is always in miles).
Supported distance units now: `mi`, `mile`, `miles`, `km`, `kilometer`, `kilometers`